### PR TITLE
 minor optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+logs/
+.git
+/thumbnails
+
+# for binarys
+*.exe
+*.exe~
+thumbinator

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ coverage.txt
 
 big_buck_bunny_480p.mp4
 /thumbnails
+
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,20 @@ ENV NGINX_TS_VERSION 0.1.1
 
 EXPOSE 8080
 
-RUN mkdir /src /config /logs /data
-RUN mkdir -p /var/media/hls
+RUN mkdir /src /config /logs /data && mkdir -p /var/media/hls
 
-RUN set -x && \
+RUN set -ex && \
   apt-get update && \
   apt-get upgrade -y && \
   apt-get clean && \
   apt-get install -y --no-install-recommends build-essential \
   wget software-properties-common && \
   apt-get install -y --no-install-recommends libpcre3-dev \
-  zlib1g-dev libssl-dev wget
+  zlib1g-dev libssl-dev wget && \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
-RUN set -x && \
+RUN set -ex && \
   wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
   tar zxf nginx-${NGINX_VERSION}.tar.gz && \
   rm nginx-${NGINX_VERSION}.tar.gz && \
@@ -30,7 +30,7 @@ RUN set -x && \
   rm v${NGINX_TS_VERSION}.tar.gz
 
 WORKDIR /src/nginx-${NGINX_VERSION}
-RUN set -x && \
+RUN set -ex && \
   ./configure --with-http_ssl_module \
   --add-module=/src/nginx-ts-module-${NGINX_TS_VERSION} \
   --with-http_stub_status_module \

--- a/cmd/thumbinator/root.go
+++ b/cmd/thumbinator/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	_ "github.com/mauricioabreu/thumbinator/logger"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	golang.org/x/net v0.0.0-20181114220301-adae6a3d119a // indirect
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -68,6 +69,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,28 @@
+package logger
+
+import (
+	"io"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const timestampFormat = "2006-01-02 15:04:05.001 -0700 MST"
+
+func init() {
+	multiWriter := io.MultiWriter(os.Stdout, &lumberjack.Logger{
+		Filename:   "logs/server.log",
+		MaxSize:    10,
+		MaxBackups: 5,
+		MaxAge:     30,
+	})
+	log.SetOutput(multiWriter)
+	log.SetLevel(log.DebugLevel)
+
+	dateFormatter := &log.JSONFormatter{
+		TimestampFormat: timestampFormat,
+	}
+	// output in JSON format
+	log.SetFormatter(dateFormatter)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,10 +12,10 @@ const timestampFormat = "2006-01-02 15:04:05.001 -0700 MST"
 
 func init() {
 	multiWriter := io.MultiWriter(os.Stdout, &lumberjack.Logger{
-		Filename:   "logs/server.log",
-		MaxSize:    10,
-		MaxBackups: 5,
-		MaxAge:     30,
+		Filename:   "logs/server.log", // Filename is the file to write logs to.  Backup log files will be retained in the same directory.
+		MaxSize:    10,                // MaxSize is the maximum size in megabytes of the log file before it gets rotated
+		MaxBackups: 5,                 // MaxBackups is the maximum number of old log files to retain.
+		MaxAge:     30,                // MaxAge is the maximum number of days to retain old log files based on the timestamp encoded in their filename.
 	})
 	log.SetOutput(multiWriter)
 	log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
Hii mauricioabreu:
just some minor opotimization
1. use log rolling package gopkg.in/natefinch/lumberjack.v2 write logs to logfile for later debuging.
2. in Dockerfile, two mkdir commands can be merge to one, this can [minimize the number of layers](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers)
3. in Dockerfile, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer.  [docker docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)